### PR TITLE
Add SMTP Certificate path configuration variables

### DIFF
--- a/config/postal.defaults.yml
+++ b/config/postal.defaults.yml
@@ -80,6 +80,8 @@ smtp:
   password: # generate the credentials within the interface.
   from_name: Postal
   from_address: postal@yourdomain.com
+  certificate_path: # By default, this will be smtp.cert, relative to this file
+  private_key_path: # By default, this will be smtp.key, relative to this file
 
 rails:
   environment: production

--- a/config/postal.example.yml
+++ b/config/postal.example.yml
@@ -57,6 +57,8 @@ smtp:
   password: # generate the credentials within the interface.
   from_name: Postal
   from_address: postal@yourdomain.com
+  certificate_path: # By default, this will be smtp.cert, relative to this file
+  private_key_path: # By default, this will be smtp.key, relative to this file
 
 rails:
   # This is generated automatically by the config initialization. It should be a random

--- a/lib/postal/config.rb
+++ b/lib/postal/config.rb
@@ -108,11 +108,11 @@ module Postal
   end
 
   def self.smtp_private_key_path
-    config_root.join('smtp.key')
+    config.smtp&.private_key_path || config_root.join('smtp.key')
   end
 
   def self.smtp_certificate_path
-    config_root.join('smtp.cert')
+    config.smtp&.certificate_path || config_root.join('smtp.cert')
   end
 
   def self.smtp_certificate_data


### PR DESCRIPTION
Adds the option of specifying the SMTP Certificates path on the file system. Resolves #45.