### PR TITLE
Fix removed ip_pool type errors

### DIFF
--- a/app/models/server.rb
+++ b/app/models/server.rb
@@ -273,7 +273,7 @@ class Server < ApplicationRecord
   end
 
   def validate_ip_pool_belongs_to_organization
-    if self.ip_pool && self.ip_pool_id_changed? && (self.ip_pool.type == 'Dedicated' && !self.organization.ip_pools.include?(self.ip_pool))
+    if self.ip_pool && self.ip_pool_id_changed? && !self.organization.ip_pools.include?(self.ip_pool)
       errors.add :ip_pool_id, "must belong to the organization"
     end
   end

--- a/app/views/servers/_form.html.haml
+++ b/app/views/servers/_form.html.haml
@@ -25,7 +25,7 @@
       .fieldSet__field
         = f.label :ip_pool_id, :class => 'fieldSet__label'
         .fieldSet__input
-          = f.collection_select :ip_pool_id, organization.ip_pools.includes(:ip_addresses).order("`default` desc, name asc"), :id, :description, {}, :class => 'input input--select'
+          = f.collection_select :ip_pool_id, organization.ip_pools.includes(:ip_addresses).order("`default` desc, name asc"), :id, :name, {}, :class => 'input input--select'
           %p.fieldSet__text
             This is the set of IP addresses which outbound e-mails will be delivered from.
 


### PR DESCRIPTION
Sice `:description` was removed from the IP pools it should display the IP pool `:name` instead of the `:description`.

Looking at 698b580db467011b7b7ae44517eafb97cc1dd43a this was overlooked.