### PR TITLE
Config to use system nameservers for DNS validation

### DIFF
--- a/app/models/domain.rb
+++ b/app/models/domain.rb
@@ -133,7 +133,7 @@ class Domain < ApplicationRecord
   end
 
   def resolver
-    @resolver ||= Resolv::DNS.new(:nameserver => nameservers)
+    @resolver ||= Postal.config.general.domain_validation_using_system_nameservers ? Resolv::DNS.new : Resolv::DNS.new(:nameserver => nameservers)
   end
 
   private

--- a/config/postal.defaults.yml
+++ b/config/postal.defaults.yml
@@ -12,6 +12,7 @@ general:
   use_ip_pools: false
   exception_url:
   maximum_delivery_attempts: 18
+  domain_validation_using_system_nameservers: false
 
 web_server:
   bind_address: 127.0.0.1


### PR DESCRIPTION
This is a PR for #55.

Some networks restrict outgoing DNS traffic for non-whitelisted nameservers, this adds a config option to use the system nameservers instead of the domain nameservers for validating if the DNS records are set correctly.