### PR TITLE
Tagging email sent via SMTP

### DIFF
--- a/lib/postal/message_db/message.rb
+++ b/lib/postal/message_db/message.rb
@@ -87,6 +87,7 @@ module Postal
         if self.raw_message
           self.subject = self.headers['subject']&.last
           self.message_id = self.headers['message-id']&.last
+          self.tag = self.headers['x-amp-tag']&.last
           if self.message_id
             self.message_id = self.message_id.gsub(/.*</, '').gsub(/>.*/, '').strip
           end


### PR DESCRIPTION
Tagging email sent with SMTP with tag passed as  "x-amp-tag" headers.