### PR TITLE
Add default tracking domain

### DIFF
--- a/app/models/server.rb
+++ b/app/models/server.rb
@@ -110,6 +110,10 @@ class Server < ApplicationRecord
     suspended_at.present? || organization.suspended?
   end
 
+  def default_tracking_domain
+    tracking_domain_id
+  end
+
   def actual_suspension_reason
     if suspended?
       if suspended_at.nil?
@@ -180,6 +184,7 @@ class Server < ApplicationRecord
     end
     [total, unverified, bad_dns]
   end
+
 
   def webhook_hash
     {

--- a/app/views/servers/_form.html.haml
+++ b/app/views/servers/_form.html.haml
@@ -31,6 +31,13 @@
 
     - if @server.persisted?
       .fieldSet__field
+        = f.label :tracking_domain_id, "Default tracking domain", :class => 'fieldSet__label'
+        .fieldSet__input
+          = f.collection_select :tracking_domain_id, @server.track_domains.where(:dns_status => "OK").order(:name), :id, :full_name, {include_blank: ''}, :class => 'input input--select'
+          %p.fieldSet__text
+            This is the default tracking domain, if no tracking domains are eligible.
+
+      .fieldSet__field
         = f.label :allow_sender, "Send as any", :class => 'fieldSet__label'
         .fieldSet__input
           .input.is-disabled= @server.allow_sender? ? "Enabled" : "Disabled"

--- a/lib/postal/message_parser.rb
+++ b/lib/postal/message_parser.rb
@@ -8,7 +8,11 @@ module Postal
       @actioned = false
       @tracked_links = 0
       @tracked_images = 0
+
       @domain = @message.server.track_domains.where(:domain => @message.domain, :dns_status => "OK").first
+      if !@domain && @message.server.default_tracking_domain
+        @domain = @message.server.track_domains.where(:id => @message.server.default_tracking_domain, :dns_status => "OK").first
+      end
 
       if @domain
         @parsed_output = generate


### PR DESCRIPTION
Adds a default tracking domain, which is used when no other tracking domains can be used.

This pull request can't be implemented as-is, unfortunately.
The database structure needs to be modified (ALTER TABLE `servers` ADD `tracking_domain_id` INT AFTER `ip_pool_id`), but I'm not sure how to implement this into the provision/migration/upgrade files.

Also, I'm not sure where to add validation (to check if the selected tracking domain is actually legit upon saving)

And do bear with me, I have absolutely no experience in Ruby/Rails, so it's been quite hit and miss for me..