### PR TITLE
Add possibility to use other ports than 80/443 in webhooks

### DIFF
--- a/app/models/webhook.rb
+++ b/app/models/webhook.rb
@@ -28,7 +28,7 @@ class Webhook < ApplicationRecord
   has_many :webhook_requests
 
   validates :name, :presence => true
-  validates :url, :presence => true, :format => {:with => /\Ahttps?\:\/\/[a-z0-9\-\.\_]+(\:\d)?[a-z0-9\-\.\_\?\&\/\+]+\z/i, :allow_blank => true}
+  validates :url, :presence => true, :format => {:with => /\Ahttps?\:\/\/[a-z0-9\-\.\_\?\&\/\+:]+\z/i, :allow_blank => true}
 
   scope :enabled, -> { where(:enabled => true) }
 

--- a/app/models/webhook.rb
+++ b/app/models/webhook.rb
@@ -28,7 +28,7 @@ class Webhook < ApplicationRecord
   has_many :webhook_requests
 
   validates :name, :presence => true
-  validates :url, :presence => true, :format => {:with => /\Ahttps?\:\/\/[a-z0-9\-\.\_\?\&\/\+]+\z/i, :allow_blank => true}
+  validates :url, :presence => true, :format => {:with => /\Ahttps?\:\/\/[a-z0-9\-\.\_]+(\:\d)?[a-z0-9\-\.\_\?\&\/\+]+\z/i, :allow_blank => true}
 
   scope :enabled, -> { where(:enabled => true) }
 


### PR DESCRIPTION
I started to use webhooks in postal and noticed that it's not possible to use a URL with a non standard port. The regex looks a bit odd. My goal was that it shouldn't change its current behavior besides the optional port. 