### PR TITLE
don't create empty parts in a multi part email

### DIFF
--- a/app/models/outgoing_message_prototype.rb
+++ b/app/models/outgoing_message_prototype.rb
@@ -163,11 +163,15 @@ class OutgoingMessagePrototype
       if @html_body.blank? && attachments.empty?
         mail.body = @plain_body
       else
-        mail.text_part = Mail::Part.new
-        mail.text_part.body = @plain_body
-        mail.html_part = Mail::Part.new
-        mail.html_part.content_type = "text/html; charset=UTF-8"
-        mail.html_part.body = @html_body
+        if !@plain_body.blank?
+          mail.text_part = Mail::Part.new
+          mail.text_part.body = @plain_body
+        end
+        if !@html_body.blank?
+          mail.html_part = Mail::Part.new
+          mail.html_part.content_type = "text/html; charset=UTF-8"
+          mail.html_part.body = @html_body
+        end
       end
       attachments.each do |attachment|
         mail.attachments[attachment[:name]] = {


### PR DESCRIPTION
Tested fix for #106 

If the user has enabled click tracking but doesn't send a HTML part, they don't get click tracking on their message so what I've done is consistent with how postal behaves currently.

If you decide that postal should auto generate a HTML part, that could be done in this part of the code too.