### PR TITLE
Smtp cert fix

### DIFF
--- a/config/postal.defaults.yml
+++ b/config/postal.defaults.yml
@@ -66,7 +66,7 @@ workers:
 smtp_server:
   port: 25
   tls_enabled: false
-  tls_certificate_path: # Defaults to config/smtp.crt
+  tls_certificate_path: # Defaults to config/smtp.cert
   tls_private_key_path: # Defaults to config/smtp.key
   proxy_protocol: false
   log_connect: true

--- a/config/postal.defaults.yml
+++ b/config/postal.defaults.yml
@@ -66,7 +66,7 @@ workers:
 smtp_server:
   port: 25
   tls_enabled: false
-  tls_certificate_path: # Defaults to config/smtp.cert
+  tls_certificate_path: # Defaults to config/smtp.crt
   tls_private_key_path: # Defaults to config/smtp.key
   proxy_protocol: false
   log_connect: true

--- a/lib/postal/smtp_sender.rb
+++ b/lib/postal/smtp_sender.rb
@@ -46,7 +46,7 @@ module Postal
               end
               next
             end
-            smtp_client = Net::SMTP.new(@remote_ip, port)
+            smtp_client = Net::SMTP.new(hostname, port)
             if @source_ip_address
               # Set the source IP as appropriate
               smtp_client.source_address = ip_type == :aaaa ? @source_ip_address.ipv6 : @source_ip_address.ipv4
@@ -236,6 +236,8 @@ module Postal
       @ssl_context_with_verify ||= begin
         c = OpenSSL::SSL::SSLContext.new
         c.verify_mode = OpenSSL::SSL::VERIFY_PEER
+        c.cert_store = OpenSSL::X509::Store.new
+        c.cert_store.set_default_paths
         c
       end
     end


### PR DESCRIPTION
Well here is the only fix for smtp certificate file name in postal defaults. It affects postal.defaults.yml only.