### PR TITLE
Configurable message size limit

### DIFF
--- a/config/postal.defaults.yml
+++ b/config/postal.defaults.yml
@@ -71,6 +71,7 @@ smtp_server:
   proxy_protocol: false
   log_connect: true
   strip_received_headers: false
+  max_message_size: 14 # size in Megabytes
 
 smtp_relays:
   -

--- a/lib/postal/message_db/provisioner.rb
+++ b/lib/postal/message_db/provisioner.rb
@@ -82,7 +82,7 @@ module Postal
         begin
           @database.query(create_table_query(table,:columns => {
               :id   =>  'int(11) NOT NULL AUTO_INCREMENT',
-              :data =>  'mediumblob DEFAULT NULL',
+              :data =>  'longblob DEFAULT NULL',
               :next =>  'int(11) DEFAULT NULL'
             }
           ))

--- a/lib/postal/smtp_server/client.rb
+++ b/lib/postal/smtp_server/client.rb
@@ -377,8 +377,8 @@ module Postal
       end
 
       def finished
-        if @data.bytesize > 14.megabytes.to_i
-          return "552 Message too large (maximum size 14MB)"
+        if @data.bytesize > Postal.config.smtp_server.max_message_size.megabytes.to_i
+          return "552 Message too large (maximum size %dMB)" % Postal.config.smtp_server.max_message_size
         end
 
         if @headers['received'].select { |r| r =~ /by #{Postal.config.dns.smtp_server_hostname}/ }.count > 4


### PR DESCRIPTION
Resolves #268.
Existing mail servers/tables needs migration. Inserting > 16M into a mediumblob column throws exception `Mysql2::Error: Data too long for column 'data' at row 1`.
Also, remember to increase [max_allowed_packet](https://mariadb.com/kb/en/library/server-system-variables/#max_allowed_packet) accordingly for MariaDB/MySQL.