### PR TITLE
Configurable SMTP server OpenSSL versions and ciphers

### DIFF
--- a/config/postal.defaults.yml
+++ b/config/postal.defaults.yml
@@ -68,6 +68,8 @@ smtp_server:
   tls_enabled: false
   tls_certificate_path: # Defaults to config/smtp.cert
   tls_private_key_path: # Defaults to config/smtp.key
+  tls_ciphers:
+  ssl_version: SSLv23
   proxy_protocol: false
   log_connect: true
   strip_received_headers: false

--- a/lib/postal/smtp_server/server.rb
+++ b/lib/postal/smtp_server/server.rb
@@ -39,7 +39,8 @@ module Postal
           ssl_context.cert = Postal.smtp_certificates[0]
           ssl_context.extra_chain_cert = Postal.smtp_certificates[1..-1]
           ssl_context.key  = Postal.smtp_private_key
-          ssl_context.ssl_version = "SSLv23"
+          ssl_context.ssl_version = Postal.config.smtp_server.ssl_version if Postal.config.smtp_server.ssl_version
+          ssl_context.ciphers = Postal.config.smtp_server.tls_ciphers if Postal.config.smtp_server.tls_ciphers
           ssl_context
         end
       end


### PR DESCRIPTION
Parts of #335
SSL version defaults to SSLv23, valid values (from OpenSSL::SSL::SSLContext::METHODS): `TLSv1, TLSv1_1, TLSv1_2, SSLv3, SSLv23`
Ciphers defaults to Ruby's defaults (OpenSSL::SSL::SSLContext::DEFAULT_PARAMS).