### PR TITLE
Use text type for links.url field

### DIFF
--- a/lib/postal/message_db/migrations/09_create_links.rb
+++ b/lib/postal/message_db/migrations/09_create_links.rb
@@ -9,7 +9,7 @@ module Postal
               :message_id                   =>  'int(11) DEFAULT NULL',
               :token                        =>  'varchar(255) DEFAULT NULL',
               :hash                         =>  'varchar(255) DEFAULT NULL',
-              :url                          =>  'varchar(255) DEFAULT NULL',
+              :url                          =>  'text',
               :timestamp                    =>  'decimal(18,6) DEFAULT NULL'
             },
             :indexes => {


### PR DESCRIPTION
Links could be up to ~2000 chars long. But now it shrinked by varchar(255).