### PR TITLE
Configurable SMTP client timeouts

### DIFF
--- a/config/postal.defaults.yml
+++ b/config/postal.defaults.yml
@@ -115,3 +115,7 @@ clamav:
   enabled: false
   host: 127.0.0.1
   port: 2000
+
+smtp_client:
+  open_timeout: 30
+  read_timeout: 60

--- a/lib/postal/smtp_sender.rb
+++ b/lib/postal/smtp_sender.rb
@@ -47,6 +47,8 @@ module Postal
               next
             end
             smtp_client = Net::SMTP.new(hostname, port)
+            smtp_client.open_timeout = Postal.config.smtp_server.open_timeout
+            smtp_client.read_timeout = Postal.config.smtp_server.read_timeout
             if @source_ip_address
               # Set the source IP as appropriate
               smtp_client.source_address = ip_type == :aaaa ? @source_ip_address.ipv6 : @source_ip_address.ipv4


### PR DESCRIPTION
A way to fix #295. Allow to configure smtp connect and read timeouts. 

Defaults set to default ruby values - 30 seconds for open (https://ruby-doc.org/stdlib-2.4.0/libdoc/net/smtp/rdoc/Net/SMTP.html#open_timeout) and 60 seconds for read (https://ruby-doc.org/stdlib-2.4.0/libdoc/net/smtp/rdoc/Net/SMTP.html#read_timeout)