### PR TITLE
missing equals sign in webhook url validation

### DIFF
--- a/app/models/webhook.rb
+++ b/app/models/webhook.rb
@@ -28,7 +28,7 @@ class Webhook < ApplicationRecord
   has_many :webhook_requests
 
   validates :name, :presence => true
-  validates :url, :presence => true, :format => {:with => /\Ahttps?\:\/\/[a-z0-9\-\.\_\?\&\/\+:]+\z/i, :allow_blank => true}
+  validates :url, :presence => true, :format => {:with => /\Ahttps?\:\/\/[a-z0-9\-\.\_\?\=\&\/\+:]+\z/i, :allow_blank => true}
 
   scope :enabled, -> { where(:enabled => true) }
 


### PR DESCRIPTION
Fix https://github.com/atech/postal/issues/475 (please read https://github.com/atech/postal/issues/475#issuecomment-362799145)