### PR TITLE
Minor spelling fixes - Change seperate/seperately to separate/separately in 2 forms

### DIFF
--- a/app/views/http_endpoints/_form.html.haml
+++ b/app/views/http_endpoints/_form.html.haml
@@ -30,9 +30,9 @@
     .fieldSet__field
       = f.label :strip_replies, :class => 'fieldSet__label'
       .fieldSet__input
-        = f.select :strip_replies, [["Send the full message as received", false], ["Try to seperate replies/signatures from plain body", true]], {}, :class => 'input input--select'
+        = f.select :strip_replies, [["Send the full message as received", false], ["Try to separate replies/signatures from plain body", true]], {}, :class => 'input input--select'
         %p.fieldSet__text
-          If enabled, we'll try to remove the replies/signatures from the plain body and send them seperately to the rest of the body.
+          If enabled, we'll try to remove the replies/signatures from the plain body and send them separately to the rest of the body.
           This is useful if you just want to see the latest message in a thread.
     .fieldSet__field
       = f.label :include_attachments, "Attachments", :class => 'fieldSet__label'

--- a/app/views/track_domains/_form.html.haml
+++ b/app/views/track_domains/_form.html.haml
@@ -17,7 +17,7 @@
       .fieldSet__input
         = f.select :ssl_enabled, [["Yes - use SSL for tracking whenever possible", true], ["No - never use SSL for tracking", false]], {}, :class => 'input input--select'
         %p.fieldSet__text
-          If enabled, we'll try to remove the replies/signatures from the plain body and send them seperately to the rest of the body.
+          If enabled, we'll try to remove the replies/signatures from the plain body and send them separately to the rest of the body.
           This is useful if you just want to see the latest message in a thread.
 
     .fieldSet__field


### PR DESCRIPTION
See PR Title