### PR TITLE
move 'Add domain' button on top of Domains page.

### DIFF
--- a/app/views/domains/index.html.haml
+++ b/app/views/domains/index.html.haml
@@ -26,6 +26,8 @@
       %p.noData__button= link_to "Add your first domain", [:new, organization, @server, :domain], :class => "button button--positive"
 
   - else
+    %p.u-center= link_to "Add new domain", [:new, organization, @server, :domain], :class => "button button--positive"
+    %br/
     %ul.domainList.u-margin
       - for domain in @domains
         %li.domainList__item
@@ -71,4 +73,3 @@
                 = link_to "DNS setup", [:setup, organization, @server, domain]
               = link_to "Delete", [organization, @server, domain], :remote => :delete, :method => :delete, :data => {:confirm => "Are you sure you wish to remove this domain?", :disable_with => "Deleting..."}, :class => 'domainList__delete'
 
-    %p.u-center= link_to "Add new domain", [:new, organization, @server, :domain], :class => "button button--positive"


### PR DESCRIPTION
Hi,

It would be awesome if the 'Add domain' button can be on top of the domains list page. 

When managing tons of domain on Postal, is annoying to go on bottom each time we want to add a domain. 

Thanks ! 

