### PR TITLE
Typo in certificate name

### DIFF
--- a/resource/nginx.cfg
+++ b/resource/nginx.cfg
@@ -10,7 +10,7 @@ server {
     listen 0.0.0.0:443 ssl;
     root /opt/postal/app/public;
     server_name postal.yourdomain.com;
-    ssl_certificate      ssl/postal.cert;
+    ssl_certificate      ssl/postal.crt;
     ssl_certificate_key  ssl/postal.key;
 
     # Generate using: openssl dhparam 4096 -out /etc/ssl/dhparam.pem


### PR DESCRIPTION
`postal.cert` => `postal.crt`