### PR TITLE
Parse multipart/related parts recursively

### DIFF
--- a/lib/postal/message_parser.rb
+++ b/lib/postal/message_parser.rb
@@ -71,7 +71,7 @@ module Postal
           part.body = parse(part.body.decoded.dup, :text)
           part.content_transfer_encoding = nil
           part.charset = 'UTF-8'
-        elsif part.content_type =~ /multipart\/alternative/
+        elsif part.content_type =~ /multipart\/(alternative|related)/
           unless part.parts.empty?
             parse_parts(part.parts)
           end


### PR DESCRIPTION
This is to ensure that tracking pixels are correctly added to all nested parts of the email.

Resolves #802.