### PR TITLE
add semicolon to DKIM record data

### DIFF
--- a/app/models/domain/dns_checks.rb
+++ b/app/models/domain/dns_checks.rb
@@ -69,7 +69,7 @@ class Domain
   # DKIM
   #
   
-  def sanatized_dkim_record
+  def sanatised_dkim_record
     return records.first.strip.ends_with?(';') ? records.first.strip : "#{records.first.strip};"
   end
   
@@ -84,7 +84,7 @@ class Domain
       if records.size > 1
         self.dkim_status = 'Invalid'
         self.dkim_error = "There are #{records.size} records for at #{domain}. There should only be one."
-      elsif sanatized_dkim_record != self.dkim_record
+      elsif sanatised_dkim_record != self.dkim_record
         self.dkim_status = 'Invalid'
         self.dkim_error = "The DKIM record at #{domain} does not match the record we have provided. Please check it has been copied correctly."
       else

--- a/app/models/domain/dns_checks.rb
+++ b/app/models/domain/dns_checks.rb
@@ -68,7 +68,11 @@ class Domain
   #
   # DKIM
   #
-
+  
+  def sanatized_dkim_record
+    return records.first.strip.ends_with?(';') ? records.first.strip : "#{records.first.strip};"
+  end
+  
   def check_dkim_record
     domain = "#{dkim_record_name}.#{name}"
     result = resolver.getresources(domain, Resolv::DNS::Resource::IN::TXT)
@@ -80,7 +84,7 @@ class Domain
       if records.size > 1
         self.dkim_status = 'Invalid'
         self.dkim_error = "There are #{records.size} records for at #{domain}. There should only be one."
-      elsif records.first.strip != self.dkim_record
+      elsif sanatized_dkim_record != self.dkim_record
         self.dkim_status = 'Invalid'
         self.dkim_error = "The DKIM record at #{domain} does not match the record we have provided. Please check it has been copied correctly."
       else

--- a/app/models/domain/dns_checks.rb
+++ b/app/models/domain/dns_checks.rb
@@ -69,7 +69,7 @@ class Domain
   # DKIM
   #
   
-  def sanatised_dkim_record
+  def sanitised_dkim_record
     return records.first.strip.ends_with?(';') ? records.first.strip : "#{records.first.strip};"
   end
   
@@ -84,7 +84,7 @@ class Domain
       if records.size > 1
         self.dkim_status = 'Invalid'
         self.dkim_error = "There are #{records.size} records for at #{domain}. There should only be one."
-      elsif sanatised_dkim_record != self.dkim_record
+      elsif sanitised_dkim_record != self.dkim_record
         self.dkim_status = 'Invalid'
         self.dkim_error = "The DKIM record at #{domain} does not match the record we have provided. Please check it has been copied correctly."
       else


### PR DESCRIPTION
Addresses https://github.com/atech/postal/issues/812

As the semicolon at the end of a DKIM record is optional, some DNS software removes it.
The above change sanitizes the DKIM record before it gets checked