### PR TITLE
Adds support for Basic Auth in HTTP Endpoint URLs

### DIFF
--- a/lib/postal/http.rb
+++ b/lib/postal/http.rb
@@ -18,8 +18,8 @@ module Postal
       request = method.new(uri.path.length == 0 ? "/" : uri.path)
       options[:headers].each { |k,v| request.add_field k, v }
 
-      if options[:username]
-        request.basic_auth(options[:username], options[:password])
+      if options[:username] || uri.user
+        request.basic_auth(options[:username] || uri.user, options[:password] || uri.password)
       end
 
       if options[:params].is_a?(Hash)


### PR DESCRIPTION
Rails Action Mailbox (released in Rails 6.0.0) uses Basic Auth to authenticate requests. Before this commit, Postal will ignore any username or password specified within the URL of an HTTP endpoint. 

By applying this commit Postal will additionally check the URL for a username/password and if found add this to the Request headers, thereby allowing users to specify an HTTP endpoint with username/password included in the URL string and allowing Postal to work with Action Mailbox.