### PR TITLE
Make it more clear that the DNS record should point to the domain

### DIFF
--- a/app/views/domains/_verify_with_dns.html.haml
+++ b/app/views/domains/_verify_with_dns.html.haml
@@ -1,6 +1,6 @@
 %p.pageContent__intro.u-margin
   To verify your ownership of <b>#{@domain.name}</b>, you need to add a TXT record to this domain.
-  The TXT record should include the value shown below.
+  The TXT record should point to the domain and include the value shown below.
 
 %pre.codeBlock.u-margin= @domain.dns_verification_string
 


### PR DESCRIPTION
This resolves #893, where one could confuse `postal-verification abcdef` for a record on the subdomain `postal-verification` with contents `abcdef`